### PR TITLE
Mark library functions as internal

### DIFF
--- a/packages/solidity-cbor/contracts/ByteParser.sol
+++ b/packages/solidity-cbor/contracts/ByteParser.sol
@@ -14,7 +14,7 @@ library ByteParser {
      * @param data dynamic bytes array
      * @return value calculated uint64 value
      */
-    function bytesToUint64(bytes memory data) public pure returns (uint64 value) {
+    function bytesToUint64(bytes memory data) internal pure returns (uint64 value) {
         require(value <= MAX_UINT64, "Number too large! Use `bytesToBigNumber` instead!");
         value = uint64(bytesToBigNumber(data));
     }
@@ -24,7 +24,7 @@ library ByteParser {
      * @param data dynamic bytes array
      * @return value calculated uint64 value
      */
-    function bytesToNegativeInt128(bytes memory data) public pure returns (int128 value) {
+    function bytesToNegativeInt128(bytes memory data) internal pure returns (int128 value) {
         value = -1 - int64(bytesToUint64(data));
     }
 
@@ -33,7 +33,7 @@ library ByteParser {
      * @param data dynamic bytes array
      * @return value converted string object
      */
-    function bytesToString(bytes memory data) public pure returns (string memory value) {
+    function bytesToString(bytes memory data) internal pure returns (string memory value) {
         value = string(data);
     }
 
@@ -42,7 +42,7 @@ library ByteParser {
      * @param data dynamic bytes array
      * @return value calculated uint256 value
      */
-    function bytesToBigNumber(bytes memory data) public pure returns (uint value) {
+    function bytesToBigNumber(bytes memory data) internal pure returns (uint value) {
         require(data.length <= 64, "Value too large!");
         for (uint i = 0; i < data.length; i++)
             value += uint8(data[i])*uint(2**(8*(data.length-(i+1))));
@@ -53,7 +53,7 @@ library ByteParser {
      * @param data dynamic bytes array
      * @return value calculated bool value
      */
-    function bytesToBool(bytes memory data) public pure returns (bool value) {
+    function bytesToBool(bytes memory data) internal pure returns (bool value) {
         require(data.length == 1, "Data is not a boolean!");
         uint8 boolean = uint8(data[0]);
         if (boolean == 1)
@@ -69,7 +69,7 @@ library ByteParser {
      * @param data dynamic bytes array
      * @return value translated address
      */
-    function parseAddr(bytes memory data) public pure returns (address value) {
+    function parseAddr(bytes memory data) internal pure returns (address value) {
         /**
          * The following function has been written by the Oraclize team, use it under the terms of the MIT license.
          * https://github.com/provable-things/ethereum-api/blob/9f34daaa550202c44f48cdee7754245074bde65d/oraclizeAPI_0.5.sol#L872-L898

--- a/packages/solidity-cbor/contracts/CBORDecoding.sol
+++ b/packages/solidity-cbor/contracts/CBORDecoding.sol
@@ -26,7 +26,7 @@ library CBORDecoding {
      */
     function decodeMapping(
         bytes memory encoding
-    ) external view returns(
+    ) internal view returns(
         bytes[2][] memory decodedData
     ) {
         uint cursor = 0;
@@ -52,7 +52,7 @@ library CBORDecoding {
      */
     function decodeArray(
         bytes memory encoding
-    ) external view returns(
+    ) internal view returns(
         bytes[] memory decodedData
     ) {
         uint cursor = 0;
@@ -78,7 +78,7 @@ library CBORDecoding {
      */
     function decodePrimitive(
         bytes memory encoding
-    ) external view returns(
+    ) internal view returns(
         bytes memory decodedData
     ) {
         uint cursor = 0;
@@ -110,7 +110,7 @@ library CBORDecoding {
     function decodeMappingGetValue(
         bytes memory encoding,
         bytes memory searchKey
-    ) external view returns(
+    ) internal view returns(
         bytes memory value
     ) {
         // Search parameters
@@ -173,7 +173,7 @@ library CBORDecoding {
     function decodeArrayGetIndex(
         bytes memory encoding,
         bytes memory searchKey
-    ) external view returns(
+    ) internal view returns(
         uint64 index
     ) {
         // Search parameters
@@ -222,7 +222,7 @@ library CBORDecoding {
     function decodeArrayGetItem(
         bytes memory encoding,
         uint64 index
-    ) external view returns(
+    ) internal view returns(
         bytes memory value
     ) {
         // Search parameters

--- a/packages/solidity-cbor/contracts/components/CBORByteUtils.sol
+++ b/packages/solidity-cbor/contracts/components/CBORByteUtils.sol
@@ -18,7 +18,7 @@ library CBORByteUtils {
         bytes memory _data,
         uint _start,
         uint _end
-    ) internal view returns (
+    ) internal pure returns (
         bytes memory slicedData
     ) {
         uint256 _length = _end - _start;
@@ -89,7 +89,7 @@ library CBORByteUtils {
      */
     function bytesToUint256(
         bytes memory data
-    ) internal view returns (
+    ) internal pure returns (
         uint256 value
     ) {
         for (uint i = 0; i < data.length; i++)

--- a/packages/solidity-cbor/contracts/components/CBORDataStructures.sol
+++ b/packages/solidity-cbor/contracts/components/CBORDataStructures.sol
@@ -44,10 +44,10 @@ library CBORDataStructures {
             uint pair = item / 2; // 0,0,1,1,2,2..
 
             // See what our field looks like
-            (Spec.MajorType majorType, uint8 shortCount, uint start, uint end, uint next) = Utils.parseField(encoding, mappingCursor);
+            (Spec.MajorType majorType, uint8 _shortCount, uint start, uint end, uint next) = Utils.parseField(encoding, mappingCursor);
 
             // Save our data
-            decodedMapping[pair][arrayIdx] = Utils.extractValue(encoding, majorType, shortCount, start, end);
+            decodedMapping[pair][arrayIdx] = Utils.extractValue(encoding, majorType, _shortCount, start, end);
 
             // Update our cursor
             mappingCursor = next;
@@ -85,10 +85,10 @@ library CBORDataStructures {
         for (uint item = 0; item < totalItems; item++) {
 
             // See what our field looks like
-            (Spec.MajorType majorType, uint8 shortCount, uint start, uint end, uint next) = Utils.parseField(encoding, arrayCursor);
+            (Spec.MajorType majorType, uint8 _shortCount, uint start, uint end, uint next) = Utils.parseField(encoding, arrayCursor);
 
             // Save our data
-            decodedArray[item] = Utils.extractValue(encoding, majorType, shortCount, start, end);
+            decodedArray[item] = Utils.extractValue(encoding, majorType, _shortCount, start, end);
 
             // Update our cursor
             arrayCursor = next;

--- a/packages/solidity-cbor/contracts/components/CBORPrimitives.sol
+++ b/packages/solidity-cbor/contracts/components/CBORPrimitives.sol
@@ -24,7 +24,7 @@ library CBORPrimitives {
         /*bytes memory encoding,*/
         uint cursor,
         uint shortCount
-    ) internal view returns (
+    ) internal pure returns (
         uint dataStart,
         uint dataEnd
     ) {
@@ -147,7 +147,7 @@ library CBORPrimitives {
         /*bytes memory encoding,*/
         uint cursor,
         uint shortCount
-    ) internal view returns (
+    ) internal pure returns (
         uint dataStart,
         uint dataEnd
     ) {

--- a/packages/solidity-cbor/contracts/components/CBORUtilities.sol
+++ b/packages/solidity-cbor/contracts/components/CBORUtilities.sol
@@ -88,7 +88,7 @@ library CBORUtilities {
         uint8 shortCount,
         uint start,
         uint end
-    ) internal view returns (
+    ) internal pure returns (
         bytes memory value
     ) {
         if (start != end)
@@ -126,7 +126,7 @@ library CBORUtilities {
      */
     function parseFieldEncoding(
         bytes1 fieldEncoding
-    ) internal view returns (
+    ) internal pure returns (
         Spec.MajorType majorType,
         uint8 shortCount
     ) {

--- a/packages/solidity-cbor/test/Benchmark.ts
+++ b/packages/solidity-cbor/test/Benchmark.ts
@@ -3,16 +3,11 @@ import { ethers } from "hardhat";
 import cbor from "cbor";
 import {
     // eslint-disable-next-line camelcase
-    CBORDecoding__factory,
-    // eslint-disable-next-line camelcase
     CBORTesting__factory,
     CBORTesting,
-    // eslint-disable-next-line camelcase
-    // ByteParser__factory,
     // eslint-disable-next-line node/no-missing-import
 } from "../typechain";
 // eslint-disable-next-line node/no-missing-import
-import { ContractFactory } from "ethers/lib/ethers";
 import { toHex } from "web3-utils";
 
 const BENCHMARK = process.env.BENCHMARK?.toLowerCase() === "true";
@@ -28,20 +23,9 @@ const BENCHMARK = process.env.BENCHMARK?.toLowerCase() === "true";
     let decoder: CBORTesting;
     // eslint-disable-next-line camelcase
     let CBORTestingFactory: CBORTesting__factory;
-    // eslint-disable-next-line camelcase
-    let CBORDecodingFactory: CBORDecoding__factory;
-    // eslint-disable-next-line camelcase
-    let ByteParserFactory: ContractFactory;
 
     before(async () => {
-        CBORDecodingFactory = await ethers.getContractFactory("CBORDecoding");
-        ByteParserFactory = await ethers.getContractFactory("ByteParser");
-        CBORTestingFactory = await ethers.getContractFactory("CBORTesting", {
-            libraries: {
-                CBORDecoding: (await CBORDecodingFactory.deploy()).address,
-                ByteParser: (await ByteParserFactory.deploy()).address,
-            },
-        });
+        CBORTestingFactory = await ethers.getContractFactory("CBORTesting");
 
         // Deploy our decoder library
         decoder = await CBORTestingFactory.deploy();

--- a/packages/solidity-cbor/test/ByteParser.ts
+++ b/packages/solidity-cbor/test/ByteParser.ts
@@ -4,16 +4,11 @@ import { ethers } from "hardhat";
 import cbor from "cbor";
 import {
     // eslint-disable-next-line camelcase
-    CBORDecoding__factory,
-    // eslint-disable-next-line camelcase
     CBORTesting__factory,
     CBORTesting,
-    // eslint-disable-next-line camelcase
-    // ByteParser__factory,
     // eslint-disable-next-line node/no-missing-import
 } from "../typechain";
 // eslint-disable-next-line node/no-missing-import
-import { ContractFactory } from "ethers/lib/ethers";
 
 describe("ByteParser.sol", function () {
     this.timeout(60_000);
@@ -22,19 +17,9 @@ describe("ByteParser.sol", function () {
     // eslint-disable-next-line camelcase
     let CBORTestingFactory: CBORTesting__factory;
     // eslint-disable-next-line camelcase
-    let CBORDecodingFactory: CBORDecoding__factory;
-    // eslint-disable-next-line camelcase
-    let ByteParserFactory: ContractFactory;
 
     before(async () => {
-        CBORDecodingFactory = await ethers.getContractFactory("CBORDecoding");
-        ByteParserFactory = await ethers.getContractFactory("ByteParser");
-        CBORTestingFactory = await ethers.getContractFactory("CBORTesting", {
-            libraries: {
-                CBORDecoding: (await CBORDecodingFactory.deploy()).address,
-                ByteParser: (await ByteParserFactory.deploy()).address,
-            },
-        });
+        CBORTestingFactory = await ethers.getContractFactory("CBORTesting");
 
         // Deploy our decoder library
         decoder = await CBORTestingFactory.deploy();

--- a/packages/solidity-cbor/test/DataStructures.ts
+++ b/packages/solidity-cbor/test/DataStructures.ts
@@ -5,14 +5,11 @@ import { ethers } from "hardhat";
 import cbor from "cbor";
 import {
     // eslint-disable-next-line camelcase
-    CBORDecoding__factory,
-    // eslint-disable-next-line camelcase
     CBORTesting__factory,
     CBORTesting,
 } from "../typechain";
 import dndData from "./sampleDatasets/dndData";
 import { toExpectedValue, listToMapping } from "./helpers/testUtils";
-import { ContractFactory } from "ethers/lib/ethers";
 import { encodeCBOR } from "./helpers/encodeCBORUtils";
 
 const MAJOR_TYPE_ARRAY = 4;
@@ -30,9 +27,6 @@ describe("CBORDataStructures.sol", function () {
     let decoder: CBORTesting;
     // eslint-disable-next-line camelcase
     let CBORTestingFactory: CBORTesting__factory;
-    // eslint-disable-next-line camelcase
-    let CBORDecodingFactory: CBORDecoding__factory;
-    let ByteParserFactory: ContractFactory;
 
     let value;
     let encoding;
@@ -40,14 +34,7 @@ describe("CBORDataStructures.sol", function () {
     let decoded;
 
     before(async () => {
-        CBORDecodingFactory = await ethers.getContractFactory("CBORDecoding");
-        ByteParserFactory = await ethers.getContractFactory("ByteParser");
-        CBORTestingFactory = await ethers.getContractFactory("CBORTesting", {
-            libraries: {
-                CBORDecoding: (await CBORDecodingFactory.deploy()).address,
-                ByteParser: (await ByteParserFactory.deploy()).address,
-            },
-        });
+        CBORTestingFactory = await ethers.getContractFactory("CBORTesting");
         // Deploy our decoder library
         decoder = await CBORTestingFactory.deploy();
     });

--- a/packages/solidity-cbor/test/Decoding.ts
+++ b/packages/solidity-cbor/test/Decoding.ts
@@ -6,13 +6,10 @@ import cbor from "cbor";
 import { toHex } from "web3-utils";
 import {
     // eslint-disable-next-line camelcase
-    CBORDecoding__factory,
-    // eslint-disable-next-line camelcase
     CBORTesting__factory,
     CBORTesting,
 } from "../typechain";
 import { toExpectedValue } from "./helpers/testUtils";
-import { ContractFactory } from "ethers/lib/ethers";
 
 describe("CBORDecoding.sol", function () {
     this.timeout(60_000);
@@ -20,23 +17,13 @@ describe("CBORDecoding.sol", function () {
     let decoder: CBORTesting;
     // eslint-disable-next-line camelcase
     let CBORTestingFactory: CBORTesting__factory;
-    // eslint-disable-next-line camelcase
-    let CBORDecodingFactory: CBORDecoding__factory;
-    let ByteParserFactory: ContractFactory;
 
     let value;
     let decoded;
     let call;
 
     before(async () => {
-        CBORDecodingFactory = await ethers.getContractFactory("CBORDecoding");
-        ByteParserFactory = await ethers.getContractFactory("ByteParser");
-        CBORTestingFactory = await ethers.getContractFactory("CBORTesting", {
-            libraries: {
-                CBORDecoding: (await CBORDecodingFactory.deploy()).address,
-                ByteParser: (await ByteParserFactory.deploy()).address,
-            },
-        });
+        CBORTestingFactory = await ethers.getContractFactory("CBORTesting");
         // Deploy our decoder library
         decoder = await CBORTestingFactory.deploy();
     });

--- a/packages/solidity-cbor/test/Primitives.ts
+++ b/packages/solidity-cbor/test/Primitives.ts
@@ -4,8 +4,6 @@ import { assert, expect } from "chai";
 import { ethers } from "hardhat";
 import {
     // eslint-disable-next-line camelcase
-    CBORDecoding__factory,
-    // eslint-disable-next-line camelcase
     CBORTesting__factory,
     CBORTesting,
 } from "../typechain";
@@ -14,7 +12,6 @@ import {
     maxValueForBytes,
     toExpectedValue,
 } from "./helpers/testUtils";
-import { ContractFactory } from "ethers/lib/ethers";
 import { encodeCBOR } from "./helpers/encodeCBORUtils";
 import BN from "bn.js";
 
@@ -46,22 +43,12 @@ describe("CBORPrimitives.sol", function () {
     let decoder: CBORTesting;
     // eslint-disable-next-line camelcase
     let CBORTestingFactory: CBORTesting__factory;
-    // eslint-disable-next-line camelcase
-    let CBORDecodingFactory: CBORDecoding__factory;
-    let ByteParserFactory: ContractFactory;
 
     let value;
     let encoding;
 
     before(async () => {
-        CBORDecodingFactory = await ethers.getContractFactory("CBORDecoding");
-        ByteParserFactory = await ethers.getContractFactory("ByteParser");
-        CBORTestingFactory = await ethers.getContractFactory("CBORTesting", {
-            libraries: {
-                CBORDecoding: (await CBORDecodingFactory.deploy()).address,
-                ByteParser: (await ByteParserFactory.deploy()).address,
-            },
-        });
+        CBORTestingFactory = await ethers.getContractFactory("CBORTesting");
         // Deploy our decoder library
         decoder = await CBORTestingFactory.deploy();
     });


### PR DESCRIPTION
https://github.com/base-org/op-enclave is using the https://github.com/marlinprotocol/NitroProver for verifying op-stack state transitions in a Nitro Enclave.

We made some refactors to the prover (see https://github.com/marlinprotocol/NitroProver/pull/1), one of which is removing the need for calling out to an external CBOR contract. This PR achieves this by replacing all of the `external` library functions with `internal`.

Also cleans up some visibility modifiers and other compiler warnings.